### PR TITLE
Add Seeing Beyond 8bits (CVPR 2026, arXiv 2603.00938)

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ CVPR 2025, [Paper](https://arxiv.org/pdf/2405.21075.pdf), [Project](https://vide
 ## Benchmarks for Evaluation
 | Name | Paper | Link | Notes |
 |:-----|:-----:|:----:|:-----:|
+| **Beyond8Bits** | [Seeing Beyond 8bits: Subjective and Objective Quality Assessment of HDR-UGC Videos](https://arxiv.org/pdf/2603.00938) | [Link](https://github.com/shreshthsaini/Beyond8Bits) | A large-scale HDR user-generated video quality benchmark, 44K videos from 6.5K sources with over 1.5M crowd ratings |
 | **Inst-IT Bench** | [Inst-IT: Boosting Multimodal Instance Understanding via Explicit Visual Prompt Instruction Tuning](https://arxiv.org/pdf/2412.03565) | [Link](https://github.com/inst-it/inst-it) | A benchmark to evaluate fine-grained instance-level understanding in images and videos |
 | **M<sup>3</sup>CoT** | [M<sup>3</sup>CoT: A Novel Benchmark for Multi-Domain Multi-step Multi-modal Chain-of-Thought](https://arxiv.org/pdf/2405.16473) | [Link](https://github.com/LightChen233/M3CoT) | A multi-domain, multi-step benchmark for multimodal CoT |
 | **MMGenBench** | [MMGenBench: Evaluating the Limits of LMMs from the Text-to-Image Generation Perspective](https://arxiv.org/pdf/2411.14062) | [Link](https://github.com/lerogo/MMGenBench) | A benchmark that gauges the performance of constructing image-generation prompt given an image |


### PR DESCRIPTION
Adds one row to **Benchmarks for Evaluation**.

**Seeing Beyond 8bits: Subjective and Objective Quality Assessment of HDR-UGC Videos** (CVPR 2026)
Shreshth Saini, Bowen Chen, Neil Birkbeck, Yilin Wang, Balu Adsumilli, Alan C. Bovik

- Paper: https://arxiv.org/abs/2603.00938
- Code: https://github.com/shreshthsaini/Beyond8Bits

Beyond8Bits is a large-scale benchmark for HDR user-generated video quality: 44K videos from 6.5K sources with over 1.5M crowd ratings. The paper also introduces HDR-Q, the first MLLM built for HDR-UGC video quality assessment, so the benchmark comes with an MLLM baseline rather than only human scores.

One note on placement: I put it in Benchmarks for Evaluation because that is where it belongs semantically, but the newest entry in that table is from Dec 2024 while recent additions elsewhere in the README go to Multimodal Instruction Tuning (& Latest Works). If you would rather it went there, or somewhere else, say the word and I will move it.

Disclosure: I am an author of this paper.
